### PR TITLE
Add internal env parser for Watcher

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -4,10 +4,7 @@ go 1.23.1
 
 replace github.com/tonkeeper/etcoen => ../.
 
-require (
-	github.com/caarlos0/env/v6 v6.10.1
-	github.com/tonkeeper/etcoen v0.0.0-20250214100313-e243303b9155
-)
+require github.com/tonkeeper/etcoen v0.0.0-20250214100313-e243303b9155
 
 require (
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,5 +1,3 @@
-github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
-github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=

--- a/example/main.go
+++ b/example/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"reflect"
-
-	"github.com/caarlos0/env/v6"
 
 	etcoen "github.com/tonkeeper/etcoen"
 )
@@ -25,9 +22,6 @@ type Config struct {
 
 func main() {
 	c := Config{}
-	if err := env.ParseWithFuncs(&c, map[reflect.Type]env.ParserFunc{}); err != nil {
-		panic(err)
-	}
 
 	watcher, err := etcoen.NewWatcher(&c)
 	if err != nil {


### PR DESCRIPTION
## Summary
- remove `caarlos0/env/v6` from example and rely on the library
- parse environment variables in `NewWatcher` using unexported helpers

## Testing
- `go vet ./...`
- `go build ./...`
- `cd example && go build`

------
https://chatgpt.com/codex/tasks/task_e_68631cbe29d0833191f8770bf3d3e5c8